### PR TITLE
좀비 스포너 수정

### DIFF
--- a/Content/Blueprints/Game/BP_ZombieSpawner.uasset
+++ b/Content/Blueprints/Game/BP_ZombieSpawner.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:35ffc25f6421fe988abede5f3f7ca34e60cbc7164335423e370300505b72667c
-size 27679
+oid sha256:fad6044ca9a67dd18c1497869a7133e9cbe57f2cb26dcbb1930f8f992351f998
+size 28145

--- a/Content/Data/Zombie/ZeroZombieSpawnDataTable.uasset
+++ b/Content/Data/Zombie/ZeroZombieSpawnDataTable.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4bfa6d7d5ebc02ba382d3b6e06fc6f4570cf2746ff326e76da8da9f115d2928e
-size 2887
+oid sha256:e340833a8c1c5d26ed240cf6abc1b3ca8f78caf8456aaac38c40c81bd200a41d
+size 6034

--- a/Source/ZeroSector/Data/ZeroZombieSpawnDataTable.h
+++ b/Source/ZeroSector/Data/ZeroZombieSpawnDataTable.h
@@ -3,7 +3,20 @@
 
 #include "CoreMinimal.h"
 #include "Engine/DataTable.h"
+#include "Character/Zombie/ZeroZombieType.h"
 #include "ZeroZombieSpawnDataTable.generated.h"
+
+USTRUCT(BlueprintType)
+struct FZeroZombieNum
+{
+	GENERATED_BODY()
+
+public:
+	FZeroZombieNum() {}
+
+	UPROPERTY(EditAnywhere, Category = "Spawn")
+	TArray<uint8> ZombieNum;
+};
 
 USTRUCT(BlueprintType)
 struct FZeroZombieSpawnDataTable : public FTableRowBase
@@ -15,5 +28,11 @@ public:
 	uint8 MaxWave;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Spawn")
-	TArray<uint8> ZombieNum;
+	int32 MaxTime;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Spawn")
+	TMap<EZombieType, FZeroZombieNum> ZombieNums;
+
+
+
 };

--- a/Source/ZeroSector/Game/ZeroGameModeBase.h
+++ b/Source/ZeroSector/Game/ZeroGameModeBase.h
@@ -57,12 +57,6 @@ public:
 	void StartTimer();
 	void RestartLevel();
 
-	UPROPERTY()
-	UAudioComponent* BGMAudioComponent = nullptr;
-
-	UPROPERTY()
-	UAudioComponent* SFXAudioComponent = nullptr;
-
 private:
 	void EndGame(bool bIsPlayerWinner);
 	
@@ -70,13 +64,8 @@ private:
 	void ChangeDayToNight();
 	void DecreaseTime();
 
+// 좀비 스폰 데이터 및 전투 스테이지 데이터
 private:
-	UPROPERTY(VisibleAnywhere, Category = "Spawner")
-	TObjectPtr<AZeroZombieSpawner> Spawner;
-
-	UPROPERTY(VisibleAnywhere, Category = "Spawner")
-	TSubclassOf<AZeroZombieSpawner> SpawnerClass;
-
 	UPROPERTY(VisibleAnywhere, Category = "Spawner")
 	TSubclassOf<AZeroWaveTrigger> WaveTriggerClass;
 
@@ -93,7 +82,19 @@ private:
 	uint8 CurrentWave;
 
 	UPROPERTY(VisibleAnywhere, Category = "Setting")
-	uint8 ZombieNum;
+	uint8 CommonZombieNum;
+
+	UPROPERTY(VisibleAnywhere, Category = "Setting")
+	uint8 RangedZombieNum;
+
+	UPROPERTY(VisibleAnywhere, Category = "Setting")
+	uint8 MiniZombieNum;
+
+	UPROPERTY(VisibleAnywhere, Category = "Setting")
+	uint8 TankerZombieNum;
+
+	UPROPERTY(VisibleAnywhere, Category = "Setting")
+	uint8 BossZombieNum;
 
 	UPROPERTY(EditAnywhere, Category = "Setting")
 	int32 MaxTime;
@@ -101,5 +102,12 @@ private:
 	FTimerHandle TimeTimerHandle;
 	bool bIsProgress = false;
 
+// Sound
+public:
+	UPROPERTY(VisibleAnywhere, Category = "Audio")
+	TObjectPtr<UAudioComponent> BGMAudioComponent;
+
+	UPROPERTY(VisibleAnywhere, Category = "Audio")
+	TObjectPtr<UAudioComponent> SFXAudioComponent;
 	
 };

--- a/Source/ZeroSector/Game/ZeroZombieSpawner.cpp
+++ b/Source/ZeroSector/Game/ZeroZombieSpawner.cpp
@@ -4,6 +4,8 @@
 #include "Game/ZeroZombieSpawner.h"
 #include "Components/SplineComponent.h"
 #include "Character/Zombie/ZeroCharacterMeleeZombie.h"
+#include "Character/Zombie/ZeroCharacterRangedZombie.h"
+#include "Character/Zombie/ZeroCharacterBossZombie.h"
 
 AZeroZombieSpawner::AZeroZombieSpawner()
 {
@@ -17,11 +19,13 @@ void AZeroZombieSpawner::BeginPlay()
 	
 }
 
-void AZeroZombieSpawner::SpawnZombie(uint8 InZombieNum)
+void AZeroZombieSpawner::SpawnZombie(uint8 CommonZombieNum, uint8 RangedZombieNum, uint8 MiniZombieNum, uint8 TankerZombieNum, uint8 BossZombieNum)
 {
+    uint8 SumOfZombieNum = CommonZombieNum + RangedZombieNum + MiniZombieNum + TankerZombieNum + BossZombieNum;
     const float SplineLength = SplineComp->GetSplineLength();
+    const float Spacing = SplineLength / SumOfZombieNum;
 
-    for (int32 i = 0; i < InZombieNum; ++i)
+    for (int32 i = 0; i < SumOfZombieNum; ++i)
     {
         float Distance = i * Spacing;
         if (Distance > SplineLength) break;
@@ -29,7 +33,31 @@ void AZeroZombieSpawner::SpawnZombie(uint8 InZombieNum)
         FVector Location = SplineComp->GetLocationAtDistanceAlongSpline(Distance, ESplineCoordinateSpace::World);
         FRotator Rotation = SplineComp->GetRotationAtDistanceAlongSpline(Distance, ESplineCoordinateSpace::World);
 
-        GetWorld()->SpawnActor<AZeroCharacterMeleeZombie>(MeleeZombieClass[static_cast<int>(FMath::RandRange(0.0, 3.0))], Location, Rotation);
+        if (i < CommonZombieNum)
+        {
+            GetWorld()->SpawnActor<AZeroCharacterMeleeZombie>(MeleeZombieClass[0], Location, Rotation);
+            continue;
+        }
+        else if (i > CommonZombieNum && i < CommonZombieNum + RangedZombieNum)
+        {
+            GetWorld()->SpawnActor<AZeroCharacterMeleeZombie>(RangedZombieClass, Location, Rotation);
+            continue;
+        }
+        else if (i > CommonZombieNum + RangedZombieNum && i < CommonZombieNum + RangedZombieNum + MiniZombieNum)
+        {
+            GetWorld()->SpawnActor<AZeroCharacterMeleeZombie>(MeleeZombieClass[1], Location, Rotation);
+            continue;
+        }
+        else if (i > CommonZombieNum + RangedZombieNum + MiniZombieNum && i < CommonZombieNum + RangedZombieNum + MiniZombieNum + TankerZombieNum)
+        {
+            GetWorld()->SpawnActor<AZeroCharacterMeleeZombie>(MeleeZombieClass[2], Location, Rotation);
+            continue;
+        }
+        else if (i > CommonZombieNum + RangedZombieNum + MiniZombieNum + TankerZombieNum)
+        {
+            GetWorld()->SpawnActor<AZeroCharacterMeleeZombie>(BossZombieClass, Location, Rotation);
+            continue;
+        }
     }
 }
 

--- a/Source/ZeroSector/Game/ZeroZombieSpawner.h
+++ b/Source/ZeroSector/Game/ZeroZombieSpawner.h
@@ -8,6 +8,8 @@
 
 class USplineComponent;
 class AZeroCharacterMeleeZombie;
+class AZeroCharacterRangedZombie;
+class AZeroCharacterBossZombie;
 
 UCLASS()
 class ZEROSECTOR_API AZeroZombieSpawner : public AActor
@@ -17,11 +19,14 @@ class ZEROSECTOR_API AZeroZombieSpawner : public AActor
 public:	
 	AZeroZombieSpawner();
 
+	FORCEINLINE uint8 GetStartDay() const { return StartDay; }
+
+
 protected:
 	virtual void BeginPlay() override;
 
 public:
-	void SpawnZombie(uint8 InZombieNum);
+	void SpawnZombie(uint8 CommonZombieNum, uint8 RangedZombieNum, uint8 MiniZombieNum, uint8 TankerZombieNum, uint8 BossZombieNum);
 
 private:
 	UPROPERTY(VisibleAnywhere, Category = "Zero")
@@ -30,10 +35,13 @@ private:
 	UPROPERTY(EditDefaultsOnly, Category = "Zero")
 	TArray<TSubclassOf<AZeroCharacterMeleeZombie>> MeleeZombieClass;
 
-	UPROPERTY(EditAnywhere, Category = "Zero")
-	int ZombieNum = 5;
+	UPROPERTY(EditDefaultsOnly, Category = "Zero")	
+	TSubclassOf<AZeroCharacterRangedZombie> RangedZombieClass;
 
-	UPROPERTY(EditAnywhere, Category = "Zero")
-	float Spacing = 200.f;
+	UPROPERTY(EditDefaultsOnly, Category = "Zero")
+	TSubclassOf<AZeroCharacterBossZombie> BossZombieClass;
+
+	UPROPERTY(EditAnywhere, Category = "Start", meta = (AllowPrivateAccess = "true"))
+	uint8 StartDay;
 
 };


### PR DESCRIPTION
관련 이슈 번호 : #101 <br><br>

좀비 스포너 데이터 테이블의 좀비 스폰 수를 기존의 TArray에서 TMap<ZombieType, TArray> 형식으로 변경 <br>
GameMode 에서는 데이터 테이블에서 종류별로 좀비 스폰 수를 가져오고, 이를 좀비 스포너에 SpawnZombie 함수의 파라미터로 넘겨줌 <br>
좀비 스포너에 StartDay 변수를 두고, GameMode 에서 TActorRange를 통해 모든 좀비 스포너를 순회하며 StartDay와 현재 Day가 같은 좀비 스포너에서 좀비 스폰<br>